### PR TITLE
FEATURE: Add debug setting to add <link> before esis

### DIFF
--- a/Configuration/Development/Settings.Debug.yaml
+++ b/Configuration/Development/Settings.Debug.yaml
@@ -1,0 +1,3 @@
+Netlogix:
+  EsiRendering:
+    debug: true

--- a/Configuration/Settings.Debug.yaml
+++ b/Configuration/Settings.Debug.yaml
@@ -1,0 +1,5 @@
+Netlogix:
+  EsiRendering:
+    # Add a <link rel="esi:include" href=""> element before each esi for debugging
+    # This setting is enabled for Development by default
+    debug: false

--- a/Resources/Private/Fusion/Components/RenderAsEsi/RenderAsEsi.fusion
+++ b/Resources/Private/Fusion/Components/RenderAsEsi/RenderAsEsi.fusion
@@ -6,10 +6,8 @@ prototype(Netlogix.EsiRendering:RenderAsEsi) {
     content = ''
 }
 
-esiRendering = Neos.Fusion:Tag {
-    tagName = 'esi:include'
-
-    attributes.src = Neos.Fusion:UriBuilder {
+esiRendering = Neos.Fusion:Component {
+    src = Neos.Fusion:UriBuilder {
         package = 'Netlogix.EsiRendering'
         controller = 'EsiRendering'
         action = 'index'
@@ -17,7 +15,28 @@ esiRendering = Neos.Fusion:Tag {
         absolute = false
     }
 
-    selfClosingTag = true
+    renderer = Neos.Fusion:Join {
+        esiUri = Neos.Fusion:Tag {
+            tagName = 'link'
+
+            attributes {
+                rel = 'esi:include'
+                'esi-identifier' = ${esiIdentifier}
+                'context-node' = ${contextNode.contextPath}
+                href = ${props.src}
+            }
+
+            @if.debug = ${Configuration.setting('Netlogix.EsiRendering.debug') == true}
+        }
+
+        esi = Neos.Fusion:Tag {
+            tagName = 'esi:include'
+
+            attributes.src = ${props.src}
+
+            selfClosingTag = true
+        }
+    }
 
     @cache {
         mode = 'cached'


### PR DESCRIPTION
This helps when debugging esi caching and lifetime. The following
attributes are added:

* rel="esi:include"
* esi-identifier="<cacheIdentifier given to RenderAsEsi>"
* context-node="<context path of the node given to RenderAsEsi>"
* href="<uri of the esi>"