### PR TITLE
BUGFIX: Include esiIdentifier in ESI uri

### DIFF
--- a/Classes/FusionObjects/RenderAsEsiImplementation.php
+++ b/Classes/FusionObjects/RenderAsEsiImplementation.php
@@ -57,6 +57,7 @@ class RenderAsEsiImplementation extends AbstractFusionObject
             'esiIdentifier' => $this->fusionValue('cacheIdentifier'),
             'contextNode' => $contextNode,
             'arguments' => [
+                'esiIdentifier' => $this->fusionValue('cacheIdentifier'),
                 'fusionPath' => $fusionPath,
                 'node' => $contextNode,
                 'hmac' => $this->hmacService->generateHmac($fusionPath, $contextNode),


### PR DESCRIPTION
This way the esiIdentifier can be taken into account
when caching the ESI response in a proxy